### PR TITLE
Allow for interpolate to be turned off globally

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ function getEntry(translations, keys) {
 function Counterpart() {
   this._registry = {
     locale: 'en',
+    interpolate: true,
     fallbackLocale: null,
     scope: null,
     translations: {},
@@ -101,6 +102,16 @@ Counterpart.prototype.setSeparator = function(value) {
   var previous = this._registry.separator;
   this._registry.separator = value;
   return previous;
+};
+
+Counterpart.prototype.setInterpolate = function(value) {
+  var previous = this._registry.interpolate;
+  this._registry.interpolate = value;
+  return previous;
+};
+
+Counterpart.prototype.getInterpolate = function() {
+  return this._registry.interpolate;
 };
 
 Counterpart.prototype.registerTranslations = function(locale, data) {
@@ -170,7 +181,7 @@ Counterpart.prototype.translate = function(key, options) {
 
   entry = this._pluralize(locale, entry, options.count);
 
-  if (options.interpolate !== false) {
+  if (this._registry.interpolate !== false && options.interpolate !== false) {
     entry = this._interpolate(entry, options);
   }
 

--- a/spec.js
+++ b/spec.js
@@ -617,6 +617,28 @@ describe('translate', function() {
     });
   });
 
+  describe('#setInterpolate', function() {
+    it('is a function', function() {
+      assert.isFunction(instance.setInterpolate);
+    });
+
+    it('sets the interpolate stored in the registry', function() {
+      var prev = instance._registry.interpolate;
+
+      instance.setInterpolate(true);
+      assert.equal(instance._registry.interpolate, true);
+
+      instance._registry.interpolate = prev;
+    });
+
+    it('returns the previous interpolate that was stored in the registry', function() {
+      var current  = instance.getInterpolate();
+      var previous = instance.setInterpolate(true);
+      assert.equal(previous, current);
+      instance.setInterpolate(current);
+    });
+  });
+
   describe('#withSeparator', function() {
     it('is a function', function() {
       assert.isFunction(instance.withSeparator);


### PR DESCRIPTION
This may be silly, but we needed to turn off interpolation globally for our app and felt it was quite painful to do this with every string. I threw this together to get it working and added the basic tests. Let me know if there are edge cases I may have not considered. 