### PR TITLE
Update so local can override global interpolate

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,6 +187,8 @@ Counterpart.prototype.translate = function(key, options) {
 
   if (this._registry.interpolate !== false && options.interpolate !== false) {
     entry = this._interpolate(entry, options);
+  } else if (!this._registry.interpolate && options.interpolate) {
+    entry = this._interpolate(entry, options);
   }
 
   return entry;

--- a/spec.js
+++ b/spec.js
@@ -326,7 +326,7 @@ describe('translate', function() {
 
         var prev = instance.setInterpolate(false);
         assert.equal(instance.translate('hello'), 'Hello from %(brand)s!');
-        assert.equal(instance.translate('hello', { interpolate: true }), 'Hello from %(brand)s!');
+        assert.equal(instance.translate('hello', { interpolate: true }), 'Hello from Z!');
         instance.setInterpolate(prev);
 
         instance._registry.interpolations = current;


### PR DESCRIPTION
In our application 99% of the strings we are using are static. In these strings there are percent signs, if we set interpolation to false globally we don't have a problem. However if we set it to true even the strings without interpolation are trying to be parsed so `27%` throws an error from sprintf.  

Our fix is to have a few of the function calls that need interpolation to set the option to true. So we can still have it globally turned off.

Also fixed a test on line 329 in that the second assert should be interpolated if the local is set to true.

Love to know your thoughts on this.