### PR TITLE
Added onTranslate hook to the translate function

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,17 @@ translate('my_namespace.greeting', { visitor: 'Martin', app_name: 'The Foo App' 
 // => 'Welcome to The Foo App, Martin!'
 ```
 
-As you can see in the last line of the example, interpolations you give as options to the `translate` function take precedence over registered interpolations.
+### Registering translate hook
+
+You can register a translate hook to interact with the parameters before the actual translation is done:
+
+```js
+translate.registerOnTranslate(function(args) {
+  console.log(args.key); // shows the original key
+  console.log(args.options); // shows the original options object
+});
+
+```
 
 ### Localization
 

--- a/index.js
+++ b/index.js
@@ -149,13 +149,25 @@ Counterpart.prototype.removeTranslationNotFoundListener = function(callback) {
   this.removeListener('translationnotfound', callback);
 };
 
+Counterpart.prototype.registerOnTranslate = function(callback) {
+  this._onTranslate = callback;
+};
+
 Counterpart.prototype.translate = function(key, options) {
+  
   if (!isArray(key) && !isString(key) || !key.length) {
     throw new Error('invalid argument: key');
   }
 
   if (isSymbol(key)) {
     key = key.substr(1);
+  }
+
+  if (this._onTranslate) {
+    var args = { key: key, options: options };
+    this._onTranslate(args);
+    key = args.key,
+    options = args.options;
   }
 
   options = extend(true, {}, options);

--- a/spec.js
+++ b/spec.js
@@ -667,6 +667,42 @@ describe('translate', function() {
     });
   });
 
+  describe('#registerOnTranslate', function() {
+    it('is a function', function() {
+      assert.isFunction(instance.registerOnTranslate);
+    });
+
+    it('is called when translating', function(done) {
+      var handler = function() { done(); };
+      instance.registerOnTranslate(handler);
+      instance.translate('foo');
+    });
+
+    describe('when called', function() {
+      it('exposes the key and options as arguments', function() {
+        var handler = function(args) { 
+          
+          assert.equal('foo', args.key);
+          assert.deepEqual({ fallback: 'bar' }, args.options);
+        };
+        instance.registerOnTranslate(handler);
+        var translation = instance.translate('foo', { fallback:'bar' });
+      });
+
+      it('can be changed by the callback', function() {
+        instance.registerTranslations('xx', { fooChanged: 'bar-changed' });
+        
+        var handler = function(args) { 
+          assert.equal('bar', args.key);
+          args.key = "fooChanged";
+        };
+        instance.registerOnTranslate(handler);
+        var translation = instance.translate('bar', { locale: 'xx' });
+        assert.equal("bar-changed", translation);
+      });
+    });
+  });
+
   describe('#getSeparator', function() {
     it('is a function', function() {
       assert.isFunction(instance.getSeparator);


### PR DESCRIPTION
This pull request will make it possible to interact with the parameters of the translate function on a global level. I am experiencing an issue with counterpart where it is not possible to lowercase my keys when translating. 

My original translations are not consistent (pascalcase, camelcase, etc), so the only thing that I can do with them to make them consistent is to lowercase the keys, but therefore counterpart also needs to lowercase them.
By adding this hook I can do:
```
counterpart.registerOnTranslate(function(args) {
    args.key.toLowerCase();
); 
```
please let me know if you think this feature is worth adding to counterpart

Thanks a lot!

Ronald