### PR TITLE
Allow trailing dot in translation keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,6 +55,7 @@ function Counterpart() {
     interpolations: {},
     normalizedKeys: {},
     separator: '.',
+    keepTrailingDot: false,
     keyTransformer: function(key) { return key; }
   };
 
@@ -299,6 +300,10 @@ Counterpart.prototype._normalizeKey = function(key, separator) {
       for (var i = keys.length - 1; i >= 0; i--) {
         if (keys[i] === '') {
           keys.splice(i, 1);
+
+          if (this._registry.keepTrailingDot === true && i == keys.length) {
+            keys[keys.length - 1] += '' + separator;
+          }
         }
       }
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
     "translate",
     "localize"
   ],
+  "scripts": {
+    "test": "make test",
+    "lint": "make lint"
+  },
   "author": {
     "name": "Martin Andert",
     "email": "mandert@gmail.com"

--- a/spec.js
+++ b/spec.js
@@ -209,6 +209,28 @@ describe('translate', function() {
             });
           });
         });
+
+        describe('with the keepTrailingDot setting set to true', function() {
+          it('returns the translation for keys that contain a trailing dot', function() {
+            instance.registerTranslations('fr', { foo: { bar: 'baz', 'With a dot.': 'Avec un point.' }, 'dot.': 'point.' });
+            instance._registry.keepTrailingDot = true;
+
+            instance.withLocale('fr', function() {
+              assert.equal(instance.translate('foo.bar'),  'baz');
+              assert.equal(instance.translate('foo.With a dot.'),  'Avec un point.');
+              assert.equal(instance.translate('dot.'),  'point.');
+
+              assert.equal(instance.translate('foo..bar'),  'baz');
+              assert.equal(instance.translate('foo..With a dot.'),  'Avec un point.');
+              assert.equal(instance.translate('.dot.'),  'point.');
+
+              assert.equal(instance.translate('foo.bar.'),  'missing translation: fr.foo.bar.');
+              assert.equal(instance.translate('foo.With a dot..'),  'missing translation: fr.foo.With a dot..');
+              assert.equal(instance.translate('foo.With. a dot.'),  'missing translation: fr.foo.With. a dot.');
+              assert.equal(instance.translate('dot..'),  'missing translation: fr.dot..');
+            });
+          });
+        });
       });
 
       describe('with a translation for a prefix of the key present', function() {


### PR DESCRIPTION
We use gettext-style translation keys (the translation key is the full text in the source lang), but prefixed with the default Counterpart's separator (`.`), so we encountered a bug when a translation key is a sentence that ends with a dot. The translation is never found.

As I saw in the code that it might have been intentional to treat the last separator as a real superfluous separator, this PR implements this with an option. But if you are ok to always keep the last dot (or other separator) as being part of the key, I can remove that setting (`_registry.keepTrailingDot`).

If you want to keep this as a setting and are ok with this PR, I can add a getter and a setter like you do for other `_registry` params. Also, I'm open to other suggestions for that param's name.

I added a test, but I was not sure if it was the right place, tell me if it's ok like this.