### PR TITLE
Allow multiple fallback locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,20 @@ To mitigate this, provide the `fallback` option with an alternate text. The foll
 translate('baz', { fallback: 'default' })
 ```
 
+Fallbacks can also contain multiple potential fallbacks. These will be tried sequentially until a key returns a successful value, or the fallbacks have been exhausted.
+
+```js
+translate('baz', { fallback: [ 'foo', 'bar', 'default' ] })
+```
+
 You can use interpolations with the `fallback` option, too.
+
+Globally, fallbackLocales can be set via the `setFallbackLocale` option.
+
+```js
+translate.setFallbackLocale('en')
+translate.setFallbackLocale([ 'bar', 'en' ])
+```
 
 ### Locales
 

--- a/README.md
+++ b/README.md
@@ -138,21 +138,6 @@ To mitigate this, provide the `fallback` option with an alternate text. The foll
 translate('baz', { fallback: 'default' })
 ```
 
-Fallbacks can also contain multiple potential fallbacks. These will be tried sequentially until a key returns a successful value, or the fallbacks have been exhausted.
-
-```js
-translate('baz', { fallback: [ 'foo', 'bar', 'default' ] })
-```
-
-You can use interpolations with the `fallback` option, too.
-
-Globally, fallbackLocales can be set via the `setFallbackLocale` option.
-
-```js
-translate.setFallbackLocale('en')
-translate.setFallbackLocale([ 'bar', 'en' ])
-```
-
 ### Locales
 
 The default locale is English ("en"). To change this, call the `setLocale` function:
@@ -190,6 +175,27 @@ translate('foo', { locale: 'de' });
 ```
 
 There are also `withScope` and `withSeparator` functions that behave exactly the same as `withLocale`.
+
+### Fallback Locales
+
+You can provide entire fallback locales as alternatives to hard-coded fallbacks.
+
+```js
+translate('baz', { fallbackLocale: 'en' });
+```
+
+Fallback locales can also contain multiple potential fallbacks. These will be tried sequentially until a key returns a successful value, or the fallback locales have been exhausted.
+
+```js
+translate('baz', { fallbackLocale: [ 'foo', 'bar', 'default' ] })
+```
+
+Globally, fallback locales can be set via the `setFallbackLocale` method. 
+
+```js
+translate.setFallbackLocale('en')
+translate.setFallbackLocale([ 'bar', 'en' ]) // Can also take multiple fallback locales
+```
 
 ### Adding Translation Data
 

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function Counterpart() {
   this._registry = {
     locale: 'en',
     interpolate: true,
-    fallbackLocale: null,
+    fallbackLocales: [],
     scope: null,
     translations: {},
     interpolations: {},
@@ -81,12 +81,12 @@ Counterpart.prototype.setLocale = function(value) {
 };
 
 Counterpart.prototype.getFallbackLocale = function() {
-  return this._registry.fallbackLocale;
+  return this._registry.fallbackLocales;
 };
 
 Counterpart.prototype.setFallbackLocale = function(value) {
-  var previous = this._registry.fallbackLocale;
-  this._registry.fallbackLocale = value;
+  var previous = this._registry.fallbackLocales;
+  this._registry.fallbackLocales = [].concat(value);
   return previous;
 };
 
@@ -183,7 +183,7 @@ Counterpart.prototype.translate = function(key, options) {
   var separator = options.separator || this._registry.separator;
   delete options.separator;
 
-  var fallbackLocale = options.fallbackLocale || this._registry.fallbackLocale;
+  var fallbackLocales = [].concat(options.fallbackLocale || this._registry.fallbackLocales);
   delete options.fallbackLocale;
 
   var keys = this._normalizeKeys(locale, scope, key, separator);
@@ -195,12 +195,16 @@ Counterpart.prototype.translate = function(key, options) {
     entry = this._fallback(locale, scope, key, options.fallback, options);
   }
 
-  if (entry === null && fallbackLocale && locale !== fallbackLocale) {
-    var fallbackKeys = this._normalizeKeys(fallbackLocale, scope, key, separator);
-    entry = getEntry(this._registry.translations, fallbackKeys);
+  if (entry === null && fallbackLocales.length > 0 && fallbackLocales.indexOf(locale) === -1) {
+    for (var ix in fallbackLocales) {
+      var fallbackLocale = fallbackLocales[ix];
+      var fallbackKeys = this._normalizeKeys(fallbackLocale, scope, key, separator);
+      entry = getEntry(this._registry.translations, fallbackKeys);
 
-    if (entry) {
-      locale = fallbackLocale;
+      if (entry) {
+        locale = fallbackLocale;
+        break;
+      }
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ Counterpart.prototype.getFallbackLocale = function() {
 
 Counterpart.prototype.setFallbackLocale = function(value) {
   var previous = this._registry.fallbackLocales;
-  this._registry.fallbackLocales = [].concat(value);
+  this._registry.fallbackLocales = [].concat(value || []);
   return previous;
 };
 


### PR DESCRIPTION
This change involves allowing multiple fallback locales to be specified and tried sequentially. Our use case requires us to have the following sort of setup:

fr-ca -> fr -> en

This necessitates more than one fallback locale.

Existing tests pass with minor modifications (ie no fallback locale is now an empty array rather than null), and new tests have been added for the new functionality.