### PR TITLE
move missing string error to console and use key as fallback

### DIFF
--- a/index.js
+++ b/index.js
@@ -209,7 +209,8 @@ Counterpart.prototype.translate = function(key, options) {
   }
 
   if (entry === null) {
-    entry = 'missing translation: ' + keys.join(separator);
+    entry = keys[1];
+    console.log('counterpart missing translation: ' + keys.join(separator));
   }
 
   entry = this._pluralize(locale, entry, options.count);


### PR DESCRIPTION
Hi, we are using counterpart to translate the react app 'riot-web'. It's working great!

This PR is to avoid passing to the user the "missing translation" error, since many people use the English fallback as key to simplify the task of translating.

So, the proposal is that the error is echoed in the console, while the user will simply see the string's key. If the key is the English string, the user won't even note the error if there is no interpolation or pluralization.