### PR TITLE
Errorhandler during translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,18 @@ instance.registerTranslations('en', { foo: 'bar' });
 instance.translate('foo');
 ```
 
+### Error handling
+
+When a translation fails, `translate` will emit an event you can listen to:
+
+```js
+translate.onError(function(err, entry, values) {
+  // do some error handling here...
+});
+```
+
+Use `translate.offError(myHandler)` to stop listening for errors.
+
 ## Contributing
 
 Here's a quick guide:

--- a/index.js
+++ b/index.js
@@ -350,7 +350,11 @@ Counterpart.prototype._interpolate = function(entry, values) {
   try {
     return sprintf(entry, extend({}, this._registry.interpolations, values));
   } catch (err) {
-    this.emit('error', err, entry, values);
+    if (this.listenerCount('error') > 0) {
+      this.emit('error', err, entry, values);
+    } else {
+      throw err;
+    }
     return null;
   }
 };

--- a/index.js
+++ b/index.js
@@ -172,6 +172,16 @@ Counterpart.prototype.removeTranslationNotFoundListener = function(callback) {
   this.removeListener('translationnotfound', callback);
 };
 
+Counterpart.prototype.onError =
+Counterpart.prototype.addErrorListener = function(callback) {
+  this.addListener('error', callback);
+};
+
+Counterpart.prototype.offError =
+Counterpart.prototype.removeErrorListener = function(callback) {
+  this.removeListener('error', callback);
+};
+
 Counterpart.prototype.translate = function(key, options) {
   if (!isArray(key) && !isString(key) || !key.length) {
     throw new Error('invalid argument: key');
@@ -337,7 +347,12 @@ Counterpart.prototype._interpolate = function(entry, values) {
     return entry;
   }
 
-  return sprintf(entry, extend({}, this._registry.interpolations, values));
+  try {
+    return sprintf(entry, extend({}, this._registry.interpolations, values));
+  } catch (err) {
+    this.emit('error', err, entry, values);
+    return null;
+  }
 };
 
 Counterpart.prototype._resolve = function(locale, scope, object, subject, options) {

--- a/spec.js
+++ b/spec.js
@@ -731,6 +731,73 @@ describe('translate', function() {
       }, 100);
     });
   });
+  
+  describe('#onError', function() {
+    it('is a function', function() {
+      assert.isFunction(instance.onError);
+    });
+
+    it('is called when the translation throws', function(done) {
+      var handler = function() { done(); };
+      instance.registerTranslations('en', { hello: 'Hello, %(name)s!' });
+      instance.onError(handler);
+      instance.translate('hello');
+      instance.offError(handler);
+    });
+
+    it('is not called when a translation succeeds', function(done) {
+      var handler = function() { done('function was called'); };
+      instance.registerTranslations('en', { hello: 'Hello, %(name)s!' });
+      instance.onError(handler);
+      instance.translate('hello', { name: 'Martin'});
+      instance.offError(handler);
+      setTimeout(done, 100);
+    });
+
+    describe('when called', function() {
+      it('exposes the error, entry and values as arguments', function(done) {
+        var handler = function(error, entry, values) {
+          assert.notEqual(undefined, error);
+          assert.equal('Hello, %(name)s!', entry);
+          assert.deepEqual({}, values);
+          done();
+        };
+
+        instance.registerTranslations('en', { hello: 'Hello, %(name)s!' });
+        instance.onError(handler);
+        instance.translate('hello');
+        instance.offError(handler);
+      });
+    });
+  });
+
+  describe('#offError', function() {
+    it('is a function', function() {
+      assert.isFunction(instance.offError);
+    });
+
+    it('stops the emission of events to the handler', function(done) {
+      var count = 0;
+
+      var handler = function() { count++; };
+
+      instance.registerTranslations('en', { hello: 'Hello, %(name)s!' });
+      instance.onError(handler);
+      instance.translate('hello');
+      instance.translate('hello');
+      instance.offError(handler);
+      
+      try {
+        instance.translate('hello');
+      } 
+      catch (err) {}
+
+      setTimeout(function() {
+        assert.equal(count, 2, 'handler was called although deactivated');
+        done();
+      }, 100);
+    });
+  });
 
   describe('#getSeparator', function() {
     it('is a function', function() {

--- a/spec.js
+++ b/spec.js
@@ -754,6 +754,13 @@ describe('translate', function() {
       setTimeout(done, 100);
     });
 
+    it('still throws when not listening for an error', function() {
+      instance.registerTranslations('en', { hello: 'Hello, %(name)s!' });
+      assert.throws(function() {
+        instance.translate('hello');
+      });
+    });
+
     describe('when called', function() {
       it('exposes the error, entry and values as arguments', function(done) {
         var handler = function(error, entry, values) {


### PR DESCRIPTION
Hi Martin,

This PR adds the ability to listen for errors during translation.

since counterpart is depending on sprintf, which can throw, I think it is a good idea to wrap the sprintf call with a try/catch block.

This add the need to listen to these errors and handle this gracefully if needed.

see:
https://github.com/alexei/sprintf.js/blob/master/src/sprintf.js#L45
https://github.com/alexei/sprintf.js/blob/master/src/sprintf.js#L62
https://github.com/alexei/sprintf.js/blob/master/src/sprintf.js#L62
... and more

What do you think?

R