### PR TITLE
Fix prototype pollution vulnerability

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,6 +190,10 @@ Counterpart.prototype.translate = function(key, options) {
     throw new Error('invalid argument: key');
   }
 
+  if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+    return key;
+  }
+
   if (isSymbol(key)) {
     key = key.substr(1);
   }
@@ -206,6 +210,10 @@ Counterpart.prototype.translate = function(key, options) {
 
   var separator = options.separator || this._registry.separator;
   delete options.separator;
+
+  if (separator === '__proto__' || separator === 'constructor' || separator === 'prototype') {
+    separator = '.';
+  }
 
   var fallbackLocales = [].concat(options.fallbackLocale || this._registry.fallbackLocales);
   delete options.fallbackLocale;
@@ -329,6 +337,10 @@ Counterpart.prototype._normalizeKey = function(key, separator) {
       var keys = key.split(separator);
 
       for (var i = keys.length - 1; i >= 0; i--) {
+        if (keys[i] === '__proto__' || keys[i] === 'constructor' || keys[i] === 'prototype') {
+          keys.splice(i, 1);
+          continue;
+        }
         if (keys[i] === '') {
           keys.splice(i, 1);
 


### PR DESCRIPTION
This PR fixes a prototype pollution vulnerability in the `translate` function.
It prevents `__proto__`, `constructor`, and `prototype` from being used as keys or separators.

This vulnerability allows attackers to inject arbitrary properties into `Object.prototype`, which can lead to XSS or other security issues in applications using this library.

Fixes #54 (if applicable, or references the issue).